### PR TITLE
Feat 202 admindropdowns

### DIFF
--- a/client/src/app.css
+++ b/client/src/app.css
@@ -26,6 +26,26 @@ html, body {
     0 1px 5px 0 rgba(0,0,0,0.2) !important;
 }
 
+.dropdown-menu {
+  box-shadow: 0 2px 2px 0 rgba(0,0,0,0.14),
+    0 3px 1px -2px rgba(0,0,0,0.12),
+    0 1px 5px 0 rgba(0,0,0,0.2) !important;
+}
+
+.dropdown-item {
+  color: var(--dk3) !important;
+  text-decoration: none !important;
+}
+
+.dropdown-item:active {
+  color: var(--lt) !important;
+  background-color: var(--m5);
+}
+
+.dropdown-toggle::after {
+    display:none
+}
+
 :root {
 
   /*-- white base: #f6f4ee;*/

--- a/client/src/app.css
+++ b/client/src/app.css
@@ -30,6 +30,7 @@ html, body {
   box-shadow: 0 2px 2px 0 rgba(0,0,0,0.14),
     0 3px 1px -2px rgba(0,0,0,0.12),
     0 1px 5px 0 rgba(0,0,0,0.2) !important;
+  top: calc(100% - 5px);
 }
 
 .dropdown-item {

--- a/client/src/app.css
+++ b/client/src/app.css
@@ -42,6 +42,11 @@ html, body {
   background-color: var(--m5);
 }
 
+.dropdown-toggle,
+.dropdown-item {
+  cursor: pointer;
+}
+
 .dropdown-toggle::after {
     display:none
 }

--- a/client/src/modules/comments/comment-card/comment-card.css
+++ b/client/src/modules/comments/comment-card/comment-card.css
@@ -46,14 +46,12 @@
   color: var(--dk4);
 }
 
-.comment-delete-container {
-  display: flex;
+.comment-card-dropdown-container {
   position: absolute;
-  top: 10px;
-  right: 10px;
-  cursor: pointer;
+  top: 5px;
+  right: 3px;  
 }
 
-.comment-delete-container .material-icons {
+.comment-card-dropdown-container .material-icons {
   font-size: 1em;
 }

--- a/client/src/modules/comments/comment-card/comment-card.html
+++ b/client/src/modules/comments/comment-card/comment-card.html
@@ -20,9 +20,16 @@
   <div class="comment-card-text flex flex-align-center">
     <span>{{$ctrl.comment.text}}</span>
   </div>
-  <div class="comment-delete-container"
-    ng-if="$ctrl.comment.user._id === $ctrl.user.id"
-    ng-click="$ctrl.handleDeleteClick()">
-    <i class="material-icons">clear</i>
+  <div class="dropdown comment-card-dropdown-container"
+    ng-if="$ctrl.canEditOrDelete()">
+    <div class="dropdown-toggle" id={{'dd-'+$ctrl.comment._id}} data-toggle="dropdown">
+      <i class="material-icons">more_vert</i>
+    </div>
+    <div class="dropdown-menu dropdown-menu-right">
+      <div class="dropdown-item"
+        ng-click="$ctrl.handleDeleteClick()">
+        Delete Comment
+      </div>
+    </div>
   </div>
 </div>

--- a/client/src/modules/comments/comment-card/comment-card.html
+++ b/client/src/modules/comments/comment-card/comment-card.html
@@ -21,7 +21,7 @@
     <span>{{$ctrl.comment.text}}</span>
   </div>
   <div class="dropdown comment-card-dropdown-container"
-    ng-if="$ctrl.canEditOrDelete()">
+    ng-if="$ctrl.menuShouldAppear()">
     <div class="dropdown-toggle" id={{'dd-'+$ctrl.comment._id}} data-toggle="dropdown">
       <i class="material-icons">more_vert</i>
     </div>

--- a/client/src/modules/comments/comment-card/comment-card.js
+++ b/client/src/modules/comments/comment-card/comment-card.js
@@ -5,19 +5,26 @@ import template from './comment-card.html';
 import './comment-card.css';
 
 class CommentCardController {
-  constructor(UserService, MomentService, EventService) {
+  constructor(UserService, MomentService, EventService, GroupService) {
     this.user = UserService.user;
     this.moment = MomentService.moment;
     this.EventService = EventService;
+    this.groupOwner = GroupService.currentGroup.userId;
     this.handleDeleteClick = this.handleDeleteClick.bind(this);
+    this.canEditOrDelete = this.canEditOrDelete.bind(this);
   }
 
   handleDeleteClick() {
     this.EventService.removeCommentForEvent(this.eventId, this.comment._id);
   }
 
+  canEditOrDelete() {
+    return this.EventService.events[this.eventId].userId === this.user.id ||
+           this.userId === this.groupOwner;
+  }
+
 }
-CommentCardController.$inject = ['UserService', 'MomentService', 'EventService'];
+CommentCardController.$inject = ['UserService', 'MomentService', 'EventService', 'GroupService'];
 
 const CommentCardComponent = {
   restrict: 'E',

--- a/client/src/modules/comments/comment-card/comment-card.js
+++ b/client/src/modules/comments/comment-card/comment-card.js
@@ -11,14 +11,14 @@ class CommentCardController {
     this.EventService = EventService;
     this.groupOwner = GroupService.currentGroup.userId;
     this.handleDeleteClick = this.handleDeleteClick.bind(this);
-    this.canEditOrDelete = this.canEditOrDelete.bind(this);
+    this.menuShouldAppear = this.menuShouldAppear.bind(this);
   }
 
   handleDeleteClick() {
     this.EventService.removeCommentForEvent(this.eventId, this.comment._id);
   }
 
-  canEditOrDelete() {
+  menuShouldAppear() {
     return this.EventService.events[this.eventId].userId === this.user.id ||
            this.userId === this.groupOwner;
   }

--- a/client/src/modules/common/header/header.css
+++ b/client/src/modules/common/header/header.css
@@ -28,60 +28,25 @@
 
 .header-title span {
   font-family: 'Montserrat' !important;
+  color: var(--lt);
 }
 
 .header-container a {
   text-decoration: none !important;
-  color: var(--lt);
 }
 
 .header-user-dropdown-container {
-  height: 100%;
-  margin-right: 30px;
+  margin-right: 20px;
 }
 
 .header-user-dropdown-toggle {
   height: 100%;
-  display: flex;
   justify-content: center;
-  flex-direction: column;
   align-items: center;
   color: var(--lt);
   cursor: pointer;
 }
 
 .header-user-dropdown-menu {
-  min-width: 5rem;
-  text-align: right;
-}
-
-.header-dropdown-item-link {
-  width: 100%;
-  color: var(--dk5) !important;
-  font-size: 1em !important;
-}
-
-.header-dropdown-item {
-  width: 100% !important;
-  font-size: 1.1em;
-  padding: 0 !important;
-  cursor: pointer;
-}
-
-.header-dropdown-item:hover {
-  background-color: var(--m1) !important;
-  display: flex;
-  justify-content: flex-start;
-  align-items: stretch;
-}
-
-.header-dropdown-item-link {
-  padding: 10px !important;
-  display: inline-block;
-  width: 100%;
-  height: 100%;
-}
-
-.header-user-dropdown-container .dropdown-toggle::after {
-    display:none
+  top: calc(100% - 10px) !important;
 }

--- a/client/src/modules/common/header/header.html
+++ b/client/src/modules/common/header/header.html
@@ -4,7 +4,7 @@
   </a>
   <div class="header-user-dropdown-container dropdown">
 
-    <div class="header-user-dropdown-toggle dropdown-toggle" id="userDropdown"
+    <div class="header-user-dropdown-toggle dropdown-toggle flex-col" id="userDropdown"
       data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
       <img ng-if="$ctrl.UserService.user.profilePic" ng-src="{{$ctrl.UserService.user.profilePic}}" class="avatar">
       <i ng-if="!$ctrl.UserService.user.profilePic" class="material-icons">account_circle</i>
@@ -12,14 +12,9 @@
     </div>
 
     <div class="header-user-dropdown-menu dropdown-menu dropdown-menu-right" aria-labelledby="userDropdown">
-      <div class="header-dropdown-item dropdown-item">
-        <a class="header-dropdown-item-link" ui-sref="app.friends.list"><span>Friends</span></a>
-      </div>
-      <div class="header-dropdown-item dropdown-item">
-        <a class="header-dropdown-item-link header-logout"
-          ng-if="$ctrl.UserService.isLoggedIn" ng-click="$ctrl.logout()">Logout
-        </a>
-      </div>
+      <a class="dropdown-item" ui-sref="app.friends.list">Friends</a>
+      <a class="dropdown-item" ng-if="$ctrl.UserService.isLoggedIn"
+        ng-click="$ctrl.logout()">Logout</a>
     </div>
   </div>
 </div>

--- a/client/src/modules/group/ideas/ideas-card/ideas-card.css
+++ b/client/src/modules/group/ideas/ideas-card/ideas-card.css
@@ -24,6 +24,16 @@ ideas-card {
   flex: 1 0 auto;
 }
 
+.ideas-card-dropdown-container {
+  position: absolute;
+  right: 0px;
+}
+
+.ideas-card-dropdown-container .material-icons {
+  font-size: 1.2em;
+  color: var(--da);
+}
+
 .ideas-card-image-container {
   width: 100%;
   flex: 0 0 auto;
@@ -34,16 +44,6 @@ ideas-card {
   width: 100%;
   height: auto;
   border-radius: 3px;
-}
-
-.ideas-card-admin-delete-container {
-  position: absolute;
-  right: 3px;
-  cursor: pointer;
-}
-
-.ideas-card-admin-delete-container .material-icons {
-  font-size: 1em;
 }
 
 .ideas-card-details-container {

--- a/client/src/modules/group/ideas/ideas-card/ideas-card.html
+++ b/client/src/modules/group/ideas/ideas-card/ideas-card.html
@@ -11,8 +11,17 @@
           <span ng-if="$ctrl.EventService.events[$ctrl.eventId].description.length > 250"><a ui-sref="^.idea({ideaId: $ctrl.EventService.events[$ctrl.eventId]._id})">{{' read more'}}</a></span>
         </div>
       </div>
-      <div ng-click="$ctrl.handleDeleteClick()" class="ideas-card-admin-delete-container">
-        <i class="material-icons">delete</i>
+      <div class="dropdown ideas-card-dropdown-container"
+        ng-if="$ctrl.canEditOrDelete()">
+        <div class="dropdown-toggle" id={{'dd-'+$ctrl.eventId}} data-toggle="dropdown">
+          <i class="material-icons">more_vert</i>
+        </div>
+        <div class="dropdown-menu dropdown-menu-right">
+          <div class="dropdown-item"
+            ng-click="$ctrl.EventService.deleteEvent($ctrl.eventId)">
+            Delete Idea
+          </div>
+        </div>
       </div>
     </div>
     <div class="ideas-card-footer flex">

--- a/client/src/modules/group/ideas/ideas-card/ideas-card.html
+++ b/client/src/modules/group/ideas/ideas-card/ideas-card.html
@@ -12,7 +12,7 @@
         </div>
       </div>
       <div class="dropdown ideas-card-dropdown-container"
-        ng-if="$ctrl.canEditOrDelete()">
+        ng-if="$ctrl.menuShouldAppear()">
         <div class="dropdown-toggle" id={{'dd-'+$ctrl.eventId}} data-toggle="dropdown">
           <i class="material-icons">more_vert</i>
         </div>

--- a/client/src/modules/group/ideas/ideas-card/ideas-card.js
+++ b/client/src/modules/group/ideas/ideas-card/ideas-card.js
@@ -5,14 +5,16 @@ import template from './ideas-card.html';
 import './ideas-card.css';
 
 class IdeasCardController {
-  constructor(EventService, UserService) {
+  constructor(EventService, UserService, GroupService) {
     this.EventService = EventService;
     this.userId = UserService.user.id;
+    this.groupOwner = GroupService.currentGroup.userId;
 
     this.upVote = this.upVote.bind(this);
     this.downVote = this.downVote.bind(this);
     this.handleDeleteClick = this.handleDeleteClick.bind(this);
     this.handlePromoteClick = this.handlePromoteClick.bind(this);
+    this.canEditOrDelete = this.canEditOrDelete.bind(this);
   }
 
   handleDeleteClick() {
@@ -21,6 +23,11 @@ class IdeasCardController {
 
   handlePromoteClick() {
     this.promoteEvent(this.eventId);
+  }
+
+  canEditOrDelete() {
+    return this.EventService.events[this.eventId].userId === this.userId ||
+           this.userId === this.groupOwner;
   }
 
   upVote() {
@@ -32,7 +39,7 @@ class IdeasCardController {
   }
 }
 
-IdeasCardController.$inject = ['EventService', 'UserService'];
+IdeasCardController.$inject = ['EventService', 'UserService', 'GroupService'];
 
 const IdeasCardComponent = {
   restrict: 'E',

--- a/client/src/modules/group/ideas/ideas-card/ideas-card.js
+++ b/client/src/modules/group/ideas/ideas-card/ideas-card.js
@@ -14,7 +14,7 @@ class IdeasCardController {
     this.downVote = this.downVote.bind(this);
     this.handleDeleteClick = this.handleDeleteClick.bind(this);
     this.handlePromoteClick = this.handlePromoteClick.bind(this);
-    this.canEditOrDelete = this.canEditOrDelete.bind(this);
+    this.menuShouldAppear = this.menuShouldAppear.bind(this);
   }
 
   handleDeleteClick() {
@@ -25,7 +25,7 @@ class IdeasCardController {
     this.promoteEvent(this.eventId);
   }
 
-  canEditOrDelete() {
+  menuShouldAppear() {
     return this.EventService.events[this.eventId].userId === this.userId ||
            this.userId === this.groupOwner;
   }

--- a/client/src/modules/home/group-card/group-card.css
+++ b/client/src/modules/home/group-card/group-card.css
@@ -27,32 +27,6 @@
   cursor: pointer;
 }
 
-.group-card-delete {
-  flex: 0 0 30px;
-  cursor: pointer;
-}
-
-.group-card-delete i:hover,
-.group-card-more-details:hover,
-.group-card-title:hover {
-  color: var(--m3);
-}
-
-.group-card-bottom-menu {
-  display: flex;
-  flex: 1 0 auto;
-  justify-content: center;
-  align-items: center;
-}
-.group-card-bottom-menu a {
-  text-decoration: none;
-}
-
-.group-card-more-details {
-  display: flex;
-  margin-top: 10px;
-}
-
 .group-card-image {
   flex: 0 0 auto;
   width: 150px;

--- a/client/src/modules/home/group-card/group-card.html
+++ b/client/src/modules/home/group-card/group-card.html
@@ -10,11 +10,11 @@
         <i class="material-icons">more_vert</i>
       </div>
       <div class="dropdown-menu dropdown-menu-right">
-        <div ng-if="$ctrl.UserService.user.id === $ctrl.group.userId"
+        <div ng-if="$ctrl.canDelete()"
           class="dropdown-item" ng-click="$ctrl.GroupService.deleteGroupById($ctrl.group._id)">
           Delete Group
         </div>
-        <div ng-if="$ctrl.UserService.user.id !== $ctrl.group.userId"
+        <div ng-if="$ctrl.canLeave()"
           class="dropdown-item" ng-click="$ctrl.GroupService.leaveGroup($ctrl.group._id)">
           Leave Group
         </div>

--- a/client/src/modules/home/group-card/group-card.html
+++ b/client/src/modules/home/group-card/group-card.html
@@ -5,9 +5,20 @@
       <div class="group-card-title" ui-sref="app.group.home({groupId: $ctrl.group._id})" ><span>{{$ctrl.group.title}}</span></div>
       <div class="group-card-description"><span>{{$ctrl.group.description}}</span></div>
     </div>
-    <a ng-if="$ctrl.UserService.user.id === $ctrl.group.userId"
-      class="group-card-delete" ng-click="$ctrl.GroupService.deleteGroupById($ctrl.group._id)">
-      <i class="material-icons">clear</i>
-    </a>
+    <div class="dropdown">
+      <div class="dropdown-toggle" id={{'dd-'+$ctrl.group._id}} data-toggle="dropdown">
+        <i class="material-icons">more_vert</i>
+      </div>
+      <div class="dropdown-menu dropdown-menu-right">
+        <div ng-if="$ctrl.UserService.user.id === $ctrl.group.userId"
+          class="dropdown-item" ng-click="$ctrl.GroupService.deleteGroupById($ctrl.group._id)">
+          Delete Group
+        </div>
+        <div ng-if="$ctrl.UserService.user.id !== $ctrl.group.userId"
+          class="dropdown-item" ng-click="$ctrl.GroupService.leaveGroup($ctrl.group._id)">
+          Leave Group
+        </div>
+      </div>
+    </div>
   </div>
 </div>

--- a/client/src/modules/home/group-card/group-card.js
+++ b/client/src/modules/home/group-card/group-card.js
@@ -9,6 +9,16 @@ class GroupCardController {
     this.UserService = UserService;
     this.GroupService = GroupService;
   }
+
+  canLeave() {
+    return this.UserService.user.id !== this.group.userId;
+  }
+
+  canDelete() {
+    return this.UserService.user.id === this.group.userId;
+  }
+
+
 }
 GroupCardController.$inject = ['UserService', 'GroupService'];
 

--- a/client/src/modules/home/home.spec.js
+++ b/client/src/modules/home/home.spec.js
@@ -5,6 +5,11 @@ describe('HomeModule', function() {
 
   beforeEach(angular.mock.module('app.home'));
 
+  beforeEach(angular.mock.module(function($provide) {
+    $provide.value('$state', {});
+    $provide.value('UserService', {});
+  }));
+
   beforeEach(angular.mock.inject(($rootScope, $compile, $httpBackend) => {
 
     $httpBackend.whenGET('/api/group/').respond([]);
@@ -36,6 +41,10 @@ describe('HomeController', function() {
   let HomeController;
 
   beforeEach(angular.mock.module('app.home'));
+  beforeEach(angular.mock.module(function($provide) {
+    $provide.value('$state', {});
+    $provide.value('UserService', {});
+  }));
   beforeEach(angular.mock.inject(($componentController) => {
     HomeController = $componentController('home', null, {});
   }));

--- a/client/src/services/group/group.service.js
+++ b/client/src/services/group/group.service.js
@@ -2,6 +2,7 @@ export default class GroupService {
   constructor($http, UserService) {
     this.$inject = ['$http', 'UserService'];
     this.http = $http;
+    this.UserService = UserService;
     this.groups = [];
     this.currentGroup = null;
   }
@@ -19,7 +20,6 @@ export default class GroupService {
     } else {
       return this.getGroupById(groupId).then(group => this.currentGroup = group);
     }
-
   }
 
   getGroupById(groupId) {
@@ -51,7 +51,7 @@ export default class GroupService {
   }
 
   leaveGroup(groupId) {
-    return this.http.put(`/api/group/${groupId}/members/remove/${UserService.user.id}`)
+    return this.http.put(`/api/group/${groupId}/members/remove/${this.UserService.user.id}`)
       .then(() => {
         const ind = this.groups.findIndex(g => g._id === groupId);
         if (ind > -1) { this.groups.splice(ind, 1); }

--- a/client/src/services/group/group.service.js
+++ b/client/src/services/group/group.service.js
@@ -1,13 +1,13 @@
 export default class GroupService {
-  constructor($http) {
-    this.$inject = ['$http'];
-    this.$http = $http;
+  constructor($http, UserService) {
+    this.$inject = ['$http', 'UserService'];
+    this.http = http;
     this.groups = [];
     this.currentGroup = null;
   }
 
   submitNewGroup(group) {
-    return this.$http.post('/api/group', group).then(resp => {
+    return this.http.post('/api/group', group).then(resp => {
       this.groups.push(resp.data);
     });
   }
@@ -23,30 +23,30 @@ export default class GroupService {
   }
 
   getGroupById(groupId) {
-    return this.$http.get(`/api/group/${groupId}`).then(resp => resp.data);
+    return this.http.get(`/api/group/${groupId}`).then(resp => resp.data);
   }
 
   deleteGroupById(groupId) {
-    return this.$http.delete(`/api/group/${groupId}`).then(() => {
+    return this.http.delete(`/api/group/${groupId}`).then(() => {
       const ind = this.groups.findIndex(g => g._id === groupId);
       if (ind > -1) { this.groups.splice(ind, 1); }
     });
   }
 
   getAllGroups() {
-    return this.$http.get('/api/group/').then((resp => {
+    return this.http.get('/api/group/').then((resp => {
       this.groups = resp.data;
       return resp.data;
     }));
   }
 
   removeMemberFromCurrentGroup(userId) {
-    return this.$http.put(`/api/group/${this.currentGroup._id}/members/remove/${userId}`)
+    return this.http.put(`/api/group/${this.currentGroup._id}/members/remove/${userId}`)
       .then(resp => this.currentGroup = resp.data);
   }
 
   addMembersToCurrentGroup(members) {
-    return this.$http.put(`/api/group/${this.currentGroup._id}/members/add`, {members})
+    return this.http.put(`/api/group/${this.currentGroup._id}/members/add`, {members})
       .then(resp => this.currentGroup = resp.data);
   }
 

--- a/client/src/services/group/group.service.js
+++ b/client/src/services/group/group.service.js
@@ -50,4 +50,12 @@ export default class GroupService {
       .then(resp => this.currentGroup = resp.data);
   }
 
+  leaveGroup(groupId) {
+    return this.http.put(`/api/group/${groupId}/members/remove/${UserService.user.id}`)
+      .then(() => {
+        const ind = this.groups.findIndex(g => g._id === groupId);
+        if (ind > -1) { this.groups.splice(ind, 1); }
+      });
+  }
+
 }

--- a/client/src/services/group/group.service.js
+++ b/client/src/services/group/group.service.js
@@ -1,7 +1,7 @@
 export default class GroupService {
   constructor($http, UserService) {
     this.$inject = ['$http', 'UserService'];
-    this.http = http;
+    this.http = $http;
     this.groups = [];
     this.currentGroup = null;
   }

--- a/db/models/event.js
+++ b/db/models/event.js
@@ -3,6 +3,7 @@ const db = require('../config.js');
 const Schema = mongoose.Schema;
 
 let eventSchema = new Schema({
+  userId: {type: Schema.ObjectId, ref: 'User', required: true},
   title: {type: String, required: true},
   addressName: {type: String, required: false},
   addressText: {type: String, required: false},

--- a/server/api/event-router.js
+++ b/server/api/event-router.js
@@ -23,6 +23,7 @@ eventRouter.post('/', (req, res) => {
   newEvent.status = 'idea';
   newEvent.upVotes = [];
   newEvent.downVotes = [];
+  newEvent.userId = req.user._id;
 
   Event.create(newEvent).then(event => res.status(201).json(event))
     .catch(err => res.status(500).json({'Server error': err}));


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13214123/32411557-2f4f21f6-c19b-11e7-83fb-1527891ddc0e.png)


closes #202 

Establishes a standard approach for dropdowns based off of bootstraps popper.js dropdowns

Example from ideas-card:
```
<div class="dropdown ideas-card-dropdown-container"
        ng-if="$ctrl.menuShouldAppear()">
        <div class="dropdown-toggle" id={{'dd-'+$ctrl.eventId}} data-toggle="dropdown">
          <i class="material-icons">more_vert</i>
        </div>
        <div class="dropdown-menu dropdown-menu-right">
          <div class="dropdown-item"
            ng-click="$ctrl.EventService.deleteEvent($ctrl.eventId)">
            Delete Idea
          </div>
        </div>
      </div>
```

**Recommendation**: pull 'should dropdown exist' logic into controllers to save from having long and complicated logic in the html directly.

I've become a fan of using methods like:
- menuShouldAppear()
- canEdit()
- canDelete()

which can be quickly defined in a controller and make the html read like ennglish




