### PR TITLE
Feat 203 confirm dialog

### DIFF
--- a/client/src/app.html
+++ b/client/src/app.html
@@ -1,4 +1,5 @@
 <div class="app-container flex-col h100">
   <header class="app-header" ng-if="$ctrl.UserService.isLoggedIn"></header>
   <ui-view class="flex-window"></ui-view>
+  <confirm></confirm>
 </div>

--- a/client/src/app.js
+++ b/client/src/app.js
@@ -17,6 +17,7 @@ import UserService from './services/user/user.service';
 import FriendService from './services/friend/friend.service';
 import MomentService from './services/moment/moment.service';
 import ImageSearchService from './services/images/image.search.service';
+import ConfirmService from './services/confirm/confirm.service';
 
 // import global styles
 import './styles/forms.css';
@@ -54,5 +55,6 @@ angular.module('app', [
   .service('FriendService', FriendService)
   .service('MomentService', MomentService)
   .service('ImageSearchService', ImageSearchService)
+  .service('ConfirmService', ConfirmService)
   .config(appRouting)
   .component('app', AppComponent);

--- a/client/src/app.routing.js
+++ b/client/src/app.routing.js
@@ -249,7 +249,7 @@ redirectIfNotAuthed.$inject = ['$q', '$state', '$timeout', 'UserService'];
 const redirectToImport = function($q, $state, $timeout, UserService) {
   const result = $q.defer();
   if (localStorage.getItem('new_user')) {
-    localStorage.removeItem("new_user");
+    localStorage.removeItem('new_user');
     $timeout(() => $state.go('app.import'));
     result.resolve('true');
   } else {

--- a/client/src/modules/common/common.js
+++ b/client/src/modules/common/common.js
@@ -4,8 +4,10 @@ import angular from 'angular';
 
 // components for the common modules
 import { HeaderComponent } from './header/header';
+import ConfirmComponent from './confirm/confirm';
 
 const CommonModule = angular.module('app.common', [])
-  .component('header', HeaderComponent);
+  .component('header', HeaderComponent)
+  .component('confirm', ConfirmComponent);
 
 export default CommonModule.name;

--- a/client/src/modules/common/confirm/confirm.css
+++ b/client/src/modules/common/confirm/confirm.css
@@ -14,15 +14,37 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  max-width: 80%;
+  max-width: 90%;
+  padding: 10px;
+  border-radius: 5px;
 }
 
 .confirm-title {
-  font-size: 1.2em;
+  font-size: 1.1em;
   color: var(--dk3);
+  margin-bottom: 5px;
 }
 
 .confirm-desc {
   font-size: .9em;
   color: var(--da);
+  margin-bottom: 5px;
+}
+
+.confirm-actions-container {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-around;
+}
+
+.confirm-actions-container .awgd-button,
+.confirm-actions-container .awgl-button {
+  flex: 1 1 100px;
+  margin: 5px 20px;
+}
+
+@media(max-width: 333px) {
+  .confirm-cancel {
+    order: 999;
+  }
 }

--- a/client/src/modules/common/confirm/confirm.css
+++ b/client/src/modules/common/confirm/confirm.css
@@ -1,0 +1,28 @@
+.confirm-modal-container {
+  position: fixed;
+  height: 100%;
+  width: 100%;
+  top: 0;
+  left: 0;
+  background-color: hsla(203, 30%, 80%, .5);
+}
+
+
+.confirm-container {
+  background-color: var(--lt);
+  position: relative;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  max-width: 80%;
+}
+
+.confirm-title {
+  font-size: 1.2em;
+  color: var(--dk3);
+}
+
+.confirm-desc {
+  font-size: .9em;
+  color: var(--da);
+}

--- a/client/src/modules/common/confirm/confirm.css
+++ b/client/src/modules/common/confirm/confirm.css
@@ -19,13 +19,13 @@
   border-radius: 5px;
 }
 
-.confirm-title {
+.confirm-prompt {
   font-size: 1.1em;
   color: var(--dk3);
   margin-bottom: 5px;
 }
 
-.confirm-desc {
+.confirm-comment {
   font-size: .9em;
   color: var(--da);
   margin-bottom: 5px;

--- a/client/src/modules/common/confirm/confirm.html
+++ b/client/src/modules/common/confirm/confirm.html
@@ -1,5 +1,5 @@
-<div class="confirm-modal-container">
-  <div class="confirm-container">
+<div class="confirm-modal-container" ng-if="$ctrl.ConfirmService.modalIsOpen">
+  <div class="confirm-container card-shadow">
     <div class="confirm-title">
         <span>{{$ctrl.ConfirmService.title}}</span>
     </div>
@@ -7,10 +7,10 @@
       <span>{{$ctrl.ConfirmService.desc}}</span>
     </div>
     <div class="confirm-actions-container">
-      <button class="awgl-button" ng-click="$ctrl.modalCancelClick()">
+      <button class="awgl-button" ng-click="$ctrl.ConfirmService.modalCancelClick()">
         {{$ctrl.ConfirmService.cancelLabel}}
       </button>
-      <button class="awgl-button" ng-click="$ctrl.modalOkClick()">
+      <button class="awgl-button" ng-click="$ctrl.ConfirmService.modalOkClick()">
         {{$ctrl.ConfirmService.okLabel}}
       </button>
     </div>

--- a/client/src/modules/common/confirm/confirm.html
+++ b/client/src/modules/common/confirm/confirm.html
@@ -1,4 +1,5 @@
-<div class="confirm-modal-container" ng-if="$ctrl.ConfirmService.modalIsOpen">
+<div class="confirm-modal-container" ng-if="$ctrl.ConfirmService.modalIsOpen"
+    ng-click="$ctrl.ConfirmService.closeModal()">
   <div class="confirm-container card-shadow">
     <div class="confirm-title">
         <span>{{$ctrl.ConfirmService.title}}</span>
@@ -7,10 +8,12 @@
       <span>{{$ctrl.ConfirmService.desc}}</span>
     </div>
     <div class="confirm-actions-container">
-      <button class="awgl-button confirm-cancel" ng-click="$ctrl.ConfirmService.modalCancelClick()">
+      <button class="awgl-button confirm-cancel"
+        ng-click="$ctrl.ConfirmService.modalCancelClick($event)">
         {{$ctrl.ConfirmService.cancelLabel}}
       </button>
-      <button class="awgd-button confirm-ok" ng-click="$ctrl.ConfirmService.modalOkClick()">
+      <button class="awgd-button confirm-ok"
+        ng-click="$ctrl.ConfirmService.modalOkClick($event)">
         {{$ctrl.ConfirmService.okLabel}}
       </button>
     </div>

--- a/client/src/modules/common/confirm/confirm.html
+++ b/client/src/modules/common/confirm/confirm.html
@@ -7,10 +7,10 @@
       <span>{{$ctrl.ConfirmService.desc}}</span>
     </div>
     <div class="confirm-actions-container">
-      <button class="awgl-button" ng-click="$ctrl.ConfirmService.modalCancelClick()">
+      <button class="awgl-button confirm-cancel" ng-click="$ctrl.ConfirmService.modalCancelClick()">
         {{$ctrl.ConfirmService.cancelLabel}}
       </button>
-      <button class="awgl-button" ng-click="$ctrl.ConfirmService.modalOkClick()">
+      <button class="awgd-button confirm-ok" ng-click="$ctrl.ConfirmService.modalOkClick()">
         {{$ctrl.ConfirmService.okLabel}}
       </button>
     </div>

--- a/client/src/modules/common/confirm/confirm.html
+++ b/client/src/modules/common/confirm/confirm.html
@@ -1,6 +1,6 @@
 <div class="confirm-modal-container" ng-if="$ctrl.ConfirmService.modalIsOpen"
     ng-click="$ctrl.ConfirmService.closeModal()">
-  <div class="confirm-container card-shadow">
+  <div class="confirm-container card-shadow" ng-click="$event.stopPropagation()">
     <div class="confirm-title">
         <span>{{$ctrl.ConfirmService.title}}</span>
     </div>

--- a/client/src/modules/common/confirm/confirm.html
+++ b/client/src/modules/common/confirm/confirm.html
@@ -1,11 +1,11 @@
 <div class="confirm-modal-container" ng-if="$ctrl.ConfirmService.modalIsOpen"
     ng-click="$ctrl.ConfirmService.closeModal()">
   <div class="confirm-container card-shadow" ng-click="$event.stopPropagation()">
-    <div class="confirm-title">
-        <span>{{$ctrl.ConfirmService.title}}</span>
+    <div class="confirm-prompt">
+        <span>{{$ctrl.ConfirmService.prompt}}</span>
     </div>
-    <div class="confirm-desc">
-      <span>{{$ctrl.ConfirmService.desc}}</span>
+    <div class="confirm-comment">
+      <span>{{$ctrl.ConfirmService.comment}}</span>
     </div>
     <div class="confirm-actions-container">
       <button class="awgl-button confirm-cancel"

--- a/client/src/modules/common/confirm/confirm.html
+++ b/client/src/modules/common/confirm/confirm.html
@@ -7,9 +7,12 @@
       <span>{{$ctrl.ConfirmService.desc}}</span>
     </div>
     <div class="confirm-actions-container">
-      <button class="awgl-button">{{$ctrl.ConfirmService.cancelLabel}}</button>
-      <button class="awgl-button">{{$ctrl.ConfirmService.okLabel}}</button>
+      <button class="awgl-button" ng-click="$ctrl.modalCancelClick()">
+        {{$ctrl.ConfirmService.cancelLabel}}
+      </button>
+      <button class="awgl-button" ng-click="$ctrl.modalOkClick()">
+        {{$ctrl.ConfirmService.okLabel}}
+      </button>
     </div>
   </div>
-
 </div>

--- a/client/src/modules/common/confirm/confirm.html
+++ b/client/src/modules/common/confirm/confirm.html
@@ -1,0 +1,15 @@
+<div class="confirm-modal-container">
+  <div class="confirm-container">
+    <div class="confirm-title">
+        <span>{{$ctrl.ConfirmService.title}}</span>
+    </div>
+    <div class="confirm-desc">
+      <span>{{$ctrl.ConfirmService.desc}}</span>
+    </div>
+    <div class="confirm-actions-container">
+      <button class="awgl-button">{{$ctrl.ConfirmService.cancelLabel}}</button>
+      <button class="awgl-button">{{$ctrl.ConfirmService.okLabel}}</button>
+    </div>
+  </div>
+
+</div>

--- a/client/src/modules/common/confirm/confirm.js
+++ b/client/src/modules/common/confirm/confirm.js
@@ -1,0 +1,22 @@
+import angular from 'angular';
+
+// imports for this component
+import template from './confirm.html';
+import './confirm.css';
+
+class ConfirmController {
+  constructor(ConfirmService) {
+    this.ConfirmService = ConfirmService;
+  }
+
+}
+ConfirmController.$inject = ['ConfirmService'];
+
+const ConfirmComponent = {
+  restrict: 'E',
+  bindings: {},
+  template: template,
+  controller: ConfirmController
+};
+
+export default ConfirmComponent;

--- a/client/src/modules/common/confirm/confirm.js
+++ b/client/src/modules/common/confirm/confirm.js
@@ -8,7 +8,6 @@ class ConfirmController {
   constructor(ConfirmService) {
     this.ConfirmService = ConfirmService;
   }
-
 }
 ConfirmController.$inject = ['ConfirmService'];
 

--- a/client/src/modules/group/people/people-list/people-list.js
+++ b/client/src/modules/group/people/people-list/people-list.js
@@ -23,7 +23,7 @@ class PeopleListController {
   remove(userId) {
     this.ConfirmService.openModal(
       'Are you sure you want to remove this user from the group?',
-      'This action cannot be undone'
+      'This action cannot be undone', 'Yes'
     ) .then(() => {
       this.GroupService.removeMemberFromCurrentGroup(userId)
         .then(() => this.refreshGroup());

--- a/client/src/modules/group/people/people-list/people-list.js
+++ b/client/src/modules/group/people/people-list/people-list.js
@@ -5,9 +5,10 @@ import template from './people-list.html';
 import './people-list.css';
 
 class PeopleListController {
-  constructor(GroupService, FriendService, UserService) {
+  constructor(GroupService, FriendService, UserService, ConfirmService) {
     this.GroupService = GroupService;
     this.UserService = UserService;
+    this.ConfirmService = ConfirmService;
     this.groupOwner = '';
     this.groupMembers = [];
     this.refreshGroup();
@@ -20,12 +21,17 @@ class PeopleListController {
   }
 
   remove(userId) {
-    this.GroupService.removeMemberFromCurrentGroup(userId)
-      .then(() => this.refreshGroup());
+    this.ConfirmService.openModal(
+      'Are you sure you want to remove this user from the group?',
+      'This action cannot be undone'
+    ) .then(() => {
+      this.GroupService.removeMemberFromCurrentGroup(userId)
+        .then(() => this.refreshGroup());
+    }).catch(() => {});
   }
 
 }
-PeopleListController.$inject = ['GroupService', 'FriendService', 'UserService'];
+PeopleListController.$inject = ['GroupService', 'FriendService', 'UserService', 'ConfirmService'];
 
 const PeopleListComponent = {
   restrict: 'E',

--- a/client/src/modules/home/group-card/group-card.html
+++ b/client/src/modules/home/group-card/group-card.html
@@ -5,17 +5,17 @@
       <div class="group-card-title" ui-sref="app.group.home({groupId: $ctrl.group._id})" ><span>{{$ctrl.group.title}}</span></div>
       <div class="group-card-description"><span>{{$ctrl.group.description}}</span></div>
     </div>
-    <div class="dropdown">
+    <div class="dropdown" ng-click="$event.preventDefault();">
       <div class="dropdown-toggle" id={{'dd-'+$ctrl.group._id}} data-toggle="dropdown">
         <i class="material-icons">more_vert</i>
       </div>
       <div class="dropdown-menu dropdown-menu-right">
         <div ng-if="$ctrl.canDelete()"
-          class="dropdown-item" ng-click="$ctrl.GroupService.deleteGroupById($ctrl.group._id)">
+          class="dropdown-item" ng-click="$ctrl.deleteGroup()">
           Delete Group
         </div>
         <div ng-if="$ctrl.canLeave()"
-          class="dropdown-item" ng-click="$ctrl.GroupService.leaveGroup($ctrl.group._id)">
+          class="dropdown-item" ng-click="$ctrl.leaveGroup()">
           Leave Group
         </div>
       </div>

--- a/client/src/modules/home/group-card/group-card.js
+++ b/client/src/modules/home/group-card/group-card.js
@@ -5,9 +5,10 @@ import template from './group-card.html';
 import './group-card.css';
 
 class GroupCardController {
-  constructor(UserService, GroupService) {
+  constructor(UserService, GroupService, ConfirmService) {
     this.UserService = UserService;
     this.GroupService = GroupService;
+    this.ConfirmService = ConfirmService;
   }
 
   canLeave() {
@@ -18,9 +19,27 @@ class GroupCardController {
     return this.UserService.user.id === this.group.userId;
   }
 
+  deleteGroup() {
+    this.ConfirmService.openModal(
+      'Are you sure you want to delete this group?',
+      'This action cannot be undone', 'Yes'
+    ).then(() => {
+      this.GroupService.deleteGroupById($ctrl.group._id);
+    }).catch(() => {});
+  }
+
+  leaveGroup() {
+    this.ConfirmService.openModal(
+      'Are you sure you want to leave this group?',
+      'This action cannot be undone', 'Yes'
+    ).then(() => {
+      this.GroupService.leaveGroup($ctrl.group._id);
+    }).catch(() => {});
+  }
+
 
 }
-GroupCardController.$inject = ['UserService', 'GroupService'];
+GroupCardController.$inject = ['UserService', 'GroupService', 'ConfirmService'];
 
 const GroupCardComponent = {
   restrict: 'E',

--- a/client/src/modules/home/group-card/group-card.js
+++ b/client/src/modules/home/group-card/group-card.js
@@ -24,7 +24,7 @@ class GroupCardController {
       'Are you sure you want to delete this group?',
       'This action cannot be undone', 'Yes'
     ).then(() => {
-      this.GroupService.deleteGroupById($ctrl.group._id);
+      this.GroupService.deleteGroupById(this.group._id);
     }).catch(() => {});
   }
 

--- a/client/src/services/confirm/confirm.service.js
+++ b/client/src/services/confirm/confirm.service.js
@@ -23,8 +23,10 @@ export default class ConfirmService {
     this.modalIsOpen = false;
   }
 
+  modalOkClick() {
+  }
 
-
-
+  modalCancelClick() {
+  }
 
 }

--- a/client/src/services/confirm/confirm.service.js
+++ b/client/src/services/confirm/confirm.service.js
@@ -24,14 +24,15 @@ export default class ConfirmService {
     this.modalIsOpen = false;
   }
 
-  modalOkClick() {
+  modalOkClick($event) {
+    $event.stopPropagation();
     this.modalIsOpen = false;
-    this.result.resolve('confirmed');
+    this.result.resolve();
   }
 
-  modalCancelClick() {
-    this.modalIsOpen = false;
-    this.result.reject('cancelled');
+  modalCancelClick($event) {
+    $event.stopPropagation();
+    this.result.reject();
+    this.closeModal();
   }
-
 }

--- a/client/src/services/confirm/confirm.service.js
+++ b/client/src/services/confirm/confirm.service.js
@@ -11,12 +11,13 @@ export default class ConfirmService {
   }
 
   openModal(title, desc, okLabel, cancelLabel) {
-    this.modalIsOpen = true;
     this.title = title;
     this.desc = desc;
     this.okLabel = okLabel || 'OK';
     this.cancelLabel = cancelLabel || 'Cancel';
+    this.modalIsOpen = true;
     this.result = this.q.defer();
+    return this.result.promise;
   }
 
   closeModal() {
@@ -24,9 +25,13 @@ export default class ConfirmService {
   }
 
   modalOkClick() {
+    this.modalIsOpen = false;
+    this.result.resolve('confirmed');
   }
 
   modalCancelClick() {
+    this.modalIsOpen = false;
+    this.result.reject('cancelled');
   }
 
 }

--- a/client/src/services/confirm/confirm.service.js
+++ b/client/src/services/confirm/confirm.service.js
@@ -1,0 +1,30 @@
+export default class ConfirmService {
+  constructor($q) {
+    this.$inject = ['$q'];
+    this.q = $q;
+    this.modalIsOpen = false;
+    this.title = '';
+    this.desc = '';
+    this.okLabel = 'OK';
+    this.cancelLabel = 'Cancel';
+    this.result = null;
+  }
+
+  openModal(title, desc, okLabel, cancelLabel) {
+    this.modalIsOpen = true;
+    this.title = title;
+    this.desc = desc;
+    this.okLabel = okLabel || 'OK';
+    this.cancelLabel = cancelLabel || 'Cancel';
+    this.result = this.q.defer();
+  }
+
+  closeModal() {
+    this.modalIsOpen = false;
+  }
+
+
+
+
+
+}

--- a/client/src/services/confirm/confirm.service.js
+++ b/client/src/services/confirm/confirm.service.js
@@ -3,16 +3,16 @@ export default class ConfirmService {
     this.$inject = ['$q'];
     this.q = $q;
     this.modalIsOpen = false;
-    this.title = '';
-    this.desc = '';
+    this.prompt = '';
+    this.comment = '';
     this.okLabel = 'OK';
     this.cancelLabel = 'Cancel';
     this.result = null;
   }
 
-  openModal(title, desc, okLabel, cancelLabel) {
-    this.title = title;
-    this.desc = desc;
+  openModal(prompt, comment, okLabel, cancelLabel) {
+    this.prompt = prompt;
+    this.comment = comment;
     this.okLabel = okLabel || 'OK';
     this.cancelLabel = cancelLabel || 'Cancel';
     this.modalIsOpen = true;

--- a/client/src/services/group/group.service.js
+++ b/client/src/services/group/group.service.js
@@ -42,12 +42,20 @@ export default class GroupService {
 
   removeMemberFromCurrentGroup(userId) {
     return this.http.put(`/api/group/${this.currentGroup._id}/members/remove/${userId}`)
-      .then(resp => this.currentGroup = resp.data);
+      .then(resp => {
+        const ind = this.groups.findIndex(g => g._id === this.currentGroup._id);
+        this.groups[ind] = resp.data;
+        this.currentGroup = resp.data;
+      });
   }
 
   addMembersToCurrentGroup(members) {
     return this.http.put(`/api/group/${this.currentGroup._id}/members/add`, {members})
-      .then(resp => this.currentGroup = resp.data);
+      .then(resp => {
+        const ind = this.groups.findIndex(g => g._id === this.currentGroup._id);
+        this.groups[ind] = resp.data;
+        this.currentGroup = resp.data;
+      });
   }
 
   leaveGroup(groupId) {


### PR DESCRIPTION
closes #203 

![image](https://user-images.githubusercontent.com/13214123/32412377-586e7092-c1b3-11e7-95dd-f174d8f6c0dd.png)


provides access to a confirmation dialog, this is a one-at-a-time service-component-implementation

inject ConfirmService into your component if you need to use it, to kick off a dialog box use:
```
ConfirmService.openModal(
  'ConfirmTitle',
  'ConfirmDescription',
  'ConfirmOkayLabel',    // optional -> defaults to OK
  'ConfirmCancelLabel',  // optional -> defaults to Cancel
).then(() => run code on OK).catch(() => {});
```
usually you'll not run anything on cancel, but if necessary, do it in the catch block

clicking outside of the dialog is treated as a cancel

**Note** - it might be useful to add: `ng-click="$event.preventDefault();"` to your dropdown level element, if it is absolutely positioned next to an <a> element