### PR TITLE
adding demote event functionality for event-feed-cards

### DIFF
--- a/client/src/modules/group/group-home/event-feed/event-feed-card/event-feed-card.css
+++ b/client/src/modules/group/group-home/event-feed/event-feed-card/event-feed-card.css
@@ -6,6 +6,7 @@
   background-color: var(--lt);
   padding: 10px;
   border-bottom: 1px solid var(--la);
+  position: relative;
 }
 
 .event-feed-card-title {
@@ -39,4 +40,15 @@
 
 .event-feed-card-address-details {
   font-size: .9em;
+}
+
+.event-feed-card-dropdown-container {
+  position: absolute;
+  top: 10px;
+  right: 5px;
+}
+
+.event-feed-card-dropdown-container .material-icons {
+  font-size: 1.2em;
+  color: var(--da);
 }

--- a/client/src/modules/group/group-home/event-feed/event-feed-card/event-feed-card.html
+++ b/client/src/modules/group/group-home/event-feed/event-feed-card/event-feed-card.html
@@ -38,6 +38,18 @@
         </div>
       </div>
     </div>
+    <div class="dropdown event-feed-card-dropdown-container"
+        ng-if="$ctrl.menuShouldAppear()">
+        <div class="dropdown-toggle" id={{'dd-'+$ctrl.event._id}} data-toggle="dropdown">
+          <i class="material-icons">more_vert</i>
+        </div>
+        <div class="dropdown-menu dropdown-menu-right">
+          <div class="dropdown-item"
+            ng-click="$ctrl.handleUnscheduleEvent()">
+            Unschedule Event
+          </div>
+        </div>
+      </div>
   </div>
   <comments event-id="$ctrl.event._id"></comments>
 </div>

--- a/client/src/modules/group/group-home/event-feed/event-feed-card/event-feed-card.js
+++ b/client/src/modules/group/group-home/event-feed/event-feed-card/event-feed-card.js
@@ -5,11 +5,37 @@ import template from './event-feed-card.html';
 import './event-feed-card.css';
 
 class EventFeedCardController {
-  constructor(MomentService) {
+  constructor(MomentService, EventService, UserService, GroupService, ConfirmService) {
     this.moment = MomentService.moment;
+    this.EventService = EventService;
+    this.UserService = UserService;
+    this.GroupService = GroupService;
+    this.ConfirmService = ConfirmService;
+
+    this.busy = false;
+
+    this.menuShouldAppear = this.menuShouldAppear.bind(this);
+  }
+
+  menuShouldAppear() { // only group owner can unschedule
+    return this.UserService.user.id === this.GroupService.currentGroup.userId;
+  }
+
+  handleUnscheduleEvent() {
+    this.ConfirmService.openModal(
+      'Are you sure you want to unschedule this event?', '',
+      'Yes', 'No'
+    ).then(() => {
+      this.busy = true;
+      this.EventService.demoteEvent(this.event._id)
+        .finally(() => this.busy = false);
+    }).catch(() => {});
   }
 }
-EventFeedCardController.$inject = ['MomentService'];
+EventFeedCardController.$inject = [
+  'MomentService', 'EventService', 'UserService',
+  'GroupService', 'ConfirmService'
+];
 
 const EventFeedCardComponent = {
   restrict: 'E',


### PR DESCRIPTION
closes #243 

lets you unschedule an event through a dropdown on the group home page - only the group owner can unschedule an event