### PR TITLE
Feat 246 load on statechange

### DIFF
--- a/client/src/app.html
+++ b/client/src/app.html
@@ -2,4 +2,5 @@
   <header class="app-header" ng-if="$ctrl.UserService.isLoggedIn"></header>
   <ui-view class="awg-flex-1 awg-overflow"></ui-view>
   <confirm></confirm>
+  <spinner-box busy="$ctrl.appBusy"></spinner-box>
 </div>

--- a/client/src/app.js
+++ b/client/src/app.js
@@ -93,8 +93,8 @@ angular.module('app', [
   .config(appRouting)
   .component('app', AppComponent)
   .run(['$state', function($state) {
-    window.myAppErrorLog = [];
+    window.routingErrorLog = [];
     $state.defaultErrorHandler(function(error) {
-      window.myAppErrorLog.push(error);
+      window.routingErrorLog.push(error);
     });
   }]);

--- a/client/src/app.js
+++ b/client/src/app.js
@@ -37,11 +37,20 @@ import './app.css';
 import './styles/forms.css';
 
 class AppController {
-  constructor(UserService) {
+  constructor(UserService, $transitions) {
     this.UserService = UserService;
+    this.transitions = $transitions;
+    this.appBusy = false;
+  }
+
+  $onInit() {
+    this.transitions.onStart({}, (transition) => {
+      this.appBusy = true;
+      transition.promise.finally(() => this.appBusy = false);
+    });
   }
 }
-AppController.$inject = ['UserService'];
+AppController.$inject = ['UserService', '$transitions'];
 
 const AppComponent = {
   template: template,

--- a/client/src/app.routing.js
+++ b/client/src/app.routing.js
@@ -234,42 +234,40 @@ routing.$inject = ['$stateProvider', '$urlRouterProvider', '$locationProvider'];
 export default routing;
 
 //TODO: look into avoiding the ugly flash, possibly removing the $timeout()
-const redirectIfNotAuthed = function($q, $state, $timeout, UserService) {
+const redirectIfNotAuthed = function($q, $state, UserService) {
   const result = $q.defer();
   if (UserService.isLoggedIn) {
     result.resolve(UserService.user);
   } else {
-    $timeout(() => $state.go('login'));
-    result.reject('Not authorized, please login!');
+    $state.go('login');
   }
   return result;
 };
-redirectIfNotAuthed.$inject = ['$q', '$state', '$timeout', 'UserService'];
+redirectIfNotAuthed.$inject = ['$q', '$state', 'UserService'];
 
-const redirectToImport = function($q, $state, $timeout, UserService) {
+const redirectToImport = function($q, $state, UserService) {
   const result = $q.defer();
   if (localStorage.getItem('new_user')) {
     localStorage.removeItem('new_user');
-    $timeout(() => $state.go('app.import'));
+    $state.go('app.import');
     result.resolve('true');
   } else {
     result.resolve('true');
   }
   return result;
 };
-redirectToImport.$inject = ['$q', '$state', '$timeout'];
+redirectToImport.$inject = ['$q', '$state', 'UserService'];
 
-const skipIfAuthed = function($q, $state, $timeout, UserService) {
+const skipIfAuthed = function($q, $state, UserService) {
   const result = $q.defer();
   if (UserService.isLoggedIn) {
-    result.reject('Logged in, redirecting to home.');
-    $timeout(() => $state.go('app.home'));
+    $state.go('app.home');
   } else {
     result.resolve();
   }
   return result;
 };
-redirectIfNotAuthed.$inject = ['$q', '$state', '$timeout', 'UserService'];
+redirectIfNotAuthed.$inject = ['$q', '$state', 'UserService'];
 
 const loadFriends = function(FriendService) {
   return FriendService.loadFriends();


### PR DESCRIPTION
closes #246 

- time delayed loading screen on state change (time delay prevents loading flash on even simple route changes)
- suppressing error messages on state change supersede (redirects), so now we can force redirects without a timeout flash