### PR TITLE
Fix comment sockets

### DIFF
--- a/client/src/modules/comments/comment-card/comment-card.js
+++ b/client/src/modules/comments/comment-card/comment-card.js
@@ -30,8 +30,8 @@ class CommentCardController {
   }
 
   menuShouldAppear() {
-    return this.EventService.events[this.eventId].userId === this.user.id ||
-           this.userId === this.groupOwner;
+    return this.comment.user._id === this.user.id ||
+           this.groupOwner === this.user.id;
   }
 
 }

--- a/client/src/services/event/event.service.js
+++ b/client/src/services/event/event.service.js
@@ -12,10 +12,6 @@ export default class EventService {
     this.ideas = [];
     this.feed = [];
     this.eventSocket = null;
-
-    // HELPER METHODS to debug, remove when done!
-    window.evs = this;
-    window.triggerDigest = () => this.rootScope.$apply();
   }
 
   //===========  SOCKET LOGIC ===========\\
@@ -93,7 +89,6 @@ export default class EventService {
   }
 
   handleNewComment(comment, digest) {
-    console.log('handling new comment: ', comment, ', triggering diegest?', digest);
     if (!this.comments[comment.eventId]) {
       this.comments[comment.eventId] = [comment];
     } else {

--- a/server/api/comment-router.js
+++ b/server/api/comment-router.js
@@ -67,9 +67,19 @@ const eventPermissionsCheck = (userId, eventId) => {
 };
 
 const commentPermissionsCheck = (userId, commentId) => {
-  return Comment.findById(commentId).then(comment => {
+  let comment;
+  return Comment.findById(commentId).then(foundComment => {
+    comment = foundComment;
     if (!comment) { throw new Error('comment_not_found'); }
-    if (!comment.user.equals(userId)) { throw new Error('not_users_comment'); }
+    if (!comment.user.equals(userId)) {
+      Event.findById(comment.eventId)
+        .then(e => Group.findById(e.groupId))
+        .then(group => {
+          if (!comment.user.equals(group.userId)) {
+            throw new Error('not_users_comment');
+          }
+        });
+    }
   });
 };
 


### PR DESCRIPTION
fixes comment related bugs

 - comment sockets now live again - updated the way in which event service was pulling the updated or new comment info off of the server response

 - group owners now allowed to delete anyone's comments in that group -> had to add a bypass in the server side comment permissions check

 - comment authors can now delete their own comments anywhere... for some reason it had been event owners, not comment owners, now resolved