### PR TITLE
numerous fixes for fixing pixers and 3rd party dependency

### DIFF
--- a/client/src/app.js
+++ b/client/src/app.js
@@ -1,9 +1,4 @@
-// preloading jquery so angular will see it
-import $ from 'jquery';
-window.$ = $;
-window.jQuery = $;
-// loading angular to window for the main app.js import
-const angular = require('angular');
+import angular from 'angular';
 import uirouter from '@uirouter/angularjs';
 import ngMaterial from 'angular-material';
 import 'angular-material/angular-material.css';

--- a/client/src/modules/group/chat/chat.js
+++ b/client/src/modules/group/chat/chat.js
@@ -13,15 +13,16 @@ import template from './chat.html';
 import './chat.css';
 
 class ChatController {
-  constructor(ChatService, GroupService, UserService, $timeout) {
+  constructor(ChatService, GroupService, UserService, $timeout, $element) {
     // services
     this.ChatService = ChatService;
     this.GroupService = GroupService;
     this.groupId = GroupService.currentGroup._id;
     this.UserService = UserService;
     this.timeout = $timeout;
+    this.element = $element;
 
-    this.messagesContainer = window.$('.chat-messages-container');
+    this.messagesContainer = this.element.find('.chat-messages-container');
     this.msgsEl = this.messagesContainer[0];
     this.isScrolledToBottom = true;
 
@@ -85,7 +86,7 @@ class ChatController {
   }
 
 }
-ChatController.$inject = ['ChatService', 'GroupService', 'UserService', '$timeout'];
+ChatController.$inject = ['ChatService', 'GroupService', 'UserService', '$timeout', '$element'];
 
 const ChatComponent = {
   restrict: 'E',

--- a/client/src/modules/group/ideas/promote-idea/promote-idea.html
+++ b/client/src/modules/group/ideas/promote-idea/promote-idea.html
@@ -13,11 +13,13 @@
           <div class="date-time">
             <mdp-date-picker class="picker" mdp-placeholder="Start date"
             mdp-format="MM/DD/YYYY" ng-model="$ctrl.startTime"
-            mdp-min-date="$ctrl.startTime"
+            mdp-min-date="$ctrl.today"
+            mdp-max-date="$ctrl.endTime"
             mdp-open-on-click="true"></mdp-date-picker>
             <mdp-time-picker class="picker" mdp-placeholder="Start time"
             mdp-format="hh:mm A" ng-model="$ctrl.startTime"
-            mdp-min-date="$ctrl.startTime"
+            mdp-min-date="$ctrl.today"
+            mdp-max-date="$ctrl.endTime"
             mdp-open-on-click="true"></mdp-time-picker>
           </div>
         </div>

--- a/client/src/modules/group/ideas/promote-idea/promote-idea.js
+++ b/client/src/modules/group/ideas/promote-idea/promote-idea.js
@@ -16,6 +16,7 @@ class PromoteIdeaController {
     this.addressText = '';
     this.addressLink = '';
     this.startTime = this.moment().startOf('hour').add(1, 'hour').toDate();
+    this.today = this.moment(this.startTime);
     this.endTime = null;
     this.showEndDrawer = false;
     this.openEndDrawer = this.openEndDrawer.bind(this);

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -11,7 +11,6 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <script src="https://code.jquery.com/jquery-3.2.1.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=" crossorigin="anonymous"></script>
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
-  <script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.10.6/moment-with-locales.js"></script>
   <script defer src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.4.0/js/tether.min.js" integrity="sha384-DztdAPBWPRXSA/3eYEEUWrWCy7G5KFbe8fFjk5JAIxUYHKkDx6Qin1DkWx51bBrb" crossorigin="anonymous"></script>
   <script defer src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/js/bootstrap.min.js" integrity="sha384-vBWWzlZJ8ea9aCX4pEW3rVHjgjt7zpkNpZk+02D9phzyeVkE+jo0ieGizqPLForn" crossorigin="anonymous"></script>
   <script defer type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAlWkHu1TwP-FJhDmZB6vpTl8QfUc5zG-0&libraries=places"></script>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 var path = require('path');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
+var webpack = require('webpack');
 
 module.exports = {
   context: __dirname,
@@ -39,6 +40,9 @@ module.exports = {
       hash: true,
       filename: 'index.handlebars'
     }),
-    new ExtractTextPlugin('style-bundle.css')
+    new ExtractTextPlugin('style-bundle.css'),
+    new webpack.ProvidePlugin({
+      'moment': 'moment'
+    })
   ]
 };


### PR DESCRIPTION
added webpack provide plugin to support passing moment to 3rd party libraries
provides moment to md-pickers, supports using max and min date stuff
removes moment from main handlebars template, leaves jquery in
because bootstrap needs it and was being difficult
adds element back into chat so that it doesn't need to use jquery directly